### PR TITLE
bugfix #85 – Removed redundant mode declaration

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,7 +28,6 @@ module.exports = {
         path: paths.dist,
         filename: '[name].[contenthash].js'
     },
-    mode: 'development',
     externals: {
         paths
     },


### PR DESCRIPTION
Original issue:
* https://github.com/winniepukki/trinat/issues/85

Problem:
* The Webpack configuration seems not to be optimised

In this PR:
* Removed redundant Webpack mode declaration in Common configuration