### PR TITLE
feature #93 – Supplied the outside node click support

### DIFF
--- a/src/app/component/Reservation/Reservation.component.js
+++ b/src/app/component/Reservation/Reservation.component.js
@@ -31,6 +31,10 @@ class Reservation extends React.Component {
       );
   }
 
+  handleInsideElementClick(e) {
+      e.stopPropagation();
+  }
+
   render() {
       const {
           t,
@@ -39,8 +43,11 @@ class Reservation extends React.Component {
       } = this.props;
 
       return (
-          <div className="Reservation-Form">
-            <div className="Reservation-Form-Wrapper">
+          <div className="Reservation-Form" onClick={ handler }>
+            <div
+              className="Reservation-Form-Wrapper"
+              onClick={ this.handleInsideElementClick }
+            >
               <h2 className="custom-tac">
                 { lang === LANG_CODE_LV ? (
                     <p className="title-first">{ t('table') }</p>


### PR DESCRIPTION
Original issue:
* https://github.com/winniepukki/trinat/issues/93

Problem:
* Reservation form currently lacks the UX friendly functionality, as it closes only on clicking the corresponding button. This should extend the UX principles and support the outside area click to close Reservation

In this PR:
* Supplied the outside node click event handling support