### PR TITLE
feature #95 – Changed the translation strings

### DIFF
--- a/src/i18n/locales/lv/translation.json
+++ b/src/i18n/locales/lv/translation.json
@@ -43,7 +43,7 @@
   "footer-contact-info": "Kontakt informācija",
   "gallery": "mūsu galerija",
   "careers": "vakances",
-  "privacy-policy": "Privātuma politika",
+  "privacy-policy": "Privātums",
   "reviews": "atsauksmes",
   "loading": "Notiek datu ielāde...",
   "load-message": {


### PR DESCRIPTION
Original issue:
* https://github.com/winniepukki/trinat/issues/95

Problem:
* A privacy policy is a statement or legal document that discloses some or all of the ways a party gathers, uses, discloses, and manages a customer or client's data

In this PR:
* Changed the `privacy` translation string for improving the UI, instead of applying the SCSS stylesheets. The string contents tho does not distort the original meaning