### PR TITLE
feature/#169 – Shipped the fallback language check

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -14,6 +14,9 @@ import lv from './locales/lv.json';
 import ru from './locales/ru.json';
 import en from './locales/en.json';
 
+const fallbackLanguage = getComputedStyle(document.documentElement)
+    .getPropertyValue('--language') || 'lv';
+
 const resources = {
     lv: {
         translation: lv
@@ -28,7 +31,7 @@ const resources = {
 
 i18n.use(Backend).use(LanguageDetector).use(initReactI18next).init({
     resources,
-    fallbackLng: 'lv',
+    fallbackLng: fallbackLanguage,
     // Ensure the debugging mode is set to *false* in production
     debug: false,
     detection: {

--- a/src/sw.js
+++ b/src/sw.js
@@ -5,7 +5,7 @@
 * @license MIT
 */
 
-const cacheVersion = 'v13';
+const cacheVersion = 'v14';
 
 self.addEventListener('activate', () => {
     caches.keys().then((keyList) => Promise.all(keyList.map((key) => {


### PR DESCRIPTION
Fixes #169

Problem:
* The PWA doesn't perform the fallback language check

In this PR:
* The PWA performs check whether the device tries to inject the language setting and fallback to that language respectively.